### PR TITLE
set kubefirst macro chart back to version before bug

### DIFF
--- a/charts/kubefirst/Chart.yaml
+++ b/charts/kubefirst/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 dependencies:
 - name: console
   repository: https://charts.kubefirst.com
-  version: 2.4.14-rc62
+  version: 2.51.0
 - name: kubefirst-api
   repository: https://charts.kubefirst.com
-  version: 2.4.14-rc62
+  version: 0.96.0
 - name: kubefirst-api-ee
   repository: https://charts.kubefirst.com
-  version: 2.4.14-rc62
+  version: 0.12.0
 description: kubefirst helm chart
 name: kubefirst
 type: application


### PR DESCRIPTION
## Description
the new ci release process has a side effect on macro charts that needs to be addressed. this is to set things back to reality.
